### PR TITLE
Split Dom interaction from tEmBo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ coverage
 
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
+dist
 
 # Dependency directory
 node_modules

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,6 +4,7 @@ module.exports = function(grunt) {
   var tasks = [
     'grunt-contrib-jshint',
     'grunt-contrib-concat',
+    'grunt-browserify',
     'grunt-contrib-jasmine',
     'grunt-contrib-watch',
     'grunt-contrib-uglify',
@@ -19,19 +20,31 @@ module.exports = function(grunt) {
     jshintrc : true
   }
 
+  // *********************************************
+  // browserify
+  config.browserify = {
+    dist: {
+      files: {
+        'dist/tembo.js': ['src/Tembo.js']
+      },
+      options: {
+        standalone: true
+      }
+    }
+  }
 
   // *********************************************
   // concat
-  config.concat = {
-    dist: {
-      src: [
-        'src/Tembo.js',
-        'src/core/*.js',
-        'src/interface/*.js',
-      ],
-      dest: 'dist/tembo.js'
-    }
-  }
+  // config.concat = {
+  //   dist: {
+  //     src: [
+  //       'src/Tembo.js',
+  //       'src/core/*.js',
+  //       'src/interface/*.js',
+  //     ],
+  //     dest: 'dist/tembo.js'
+  //   }
+  // }
 
 
   // *********************************************
@@ -73,10 +86,12 @@ module.exports = function(grunt) {
 
   tasks.forEach(grunt.loadNpmTasks);
 
+  grunt.registerTask('build', ['browserify', 'uglify']);
+
   grunt.registerTask('hint', ['jshint']);
 
   grunt.registerTask('test', ['jasmine']);
 
-  grunt.registerTask('default', ['jshint', 'concat', 'uglify','watch']);
+  grunt.registerTask('default', ['jshint', 'browserify', 'uglify', 'watch']);
 
 };

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
     "test": "./node_modules/.bin/grunt"
   },
   "devDependencies": {
+    "browserify": "^13.0.0",
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.1",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-jasmine": "^0.9.1",
     "grunt-contrib-jshint": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "main": "dist/tembo.min.js",
   "scripts": {
-    "test": "grunt"
+    "install": "./node_modules/.bin/grunt build",
+    "test": "./node_modules/.bin/grunt"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-browserify": "^4.0.1",
     "grunt-contrib-concat": "^0.4.0",
     "grunt-contrib-jasmine": "^0.9.1",
     "grunt-contrib-jshint": "0.11.0",

--- a/src/Tembo.js
+++ b/src/Tembo.js
@@ -1,15 +1,28 @@
 //File : src/Tembo.js
 
-;(function(world){
-  'use strict';
+var TemboConstructor = function(){
+  var tembo = {
+    _ : {},
+    components : {}
+  };
+  require('./core/Tembo.core.can.js')(tembo);
+  require('./core/Tembo.core.componentFactory.js')(tembo);
+  require('./core/Tembo.core.deeplyCompare.js')(tembo);
+  require('./core/tembo.El.js')(tembo);
 
-  world.Tembo = function(){
-    return {
-      _ : {
-      },
-      components : {
-      }
-    };
-  }();
+  require('./interface/tembo.createClass.js')(tembo);
+  require('./interface/tembo.createElement.js')(tembo);
+  require('./interface/tembo.render.js')(tembo);
 
-})(this);
+  return tembo;
+};
+
+var Tembo = TemboConstructor();
+
+Tembo.TemboConstructor = TemboConstructor;
+
+module.exports = Tembo;
+
+if (!module.parent && typeof window === 'object'){
+  window.Tembo = Tembo;
+}

--- a/src/Tembo.js
+++ b/src/Tembo.js
@@ -1,8 +1,9 @@
 //File : src/Tembo.js
 
-var TemboConstructor = function(){
+var TemboConstructor = function(renderer){
   var tembo = {
     _ : {},
+    $ : renderer || require('./renderers/DOM.js'),
     components : {}
   };
   require('./core/Tembo.core.can.js')(tembo);

--- a/src/core/Tembo.core.can.js
+++ b/src/core/Tembo.core.can.js
@@ -1,9 +1,9 @@
 //File : src/Tembo._.can.js
 
-(function(Tembo){
+module.exports = function(Tembo){
   'use strict';
   Tembo._.can = function(label,method){
     if (!Tembo[label])
       Tembo[label] = method;
   };
-})(this.Tembo);
+};

--- a/src/core/Tembo.core.componentFactory.js
+++ b/src/core/Tembo.core.componentFactory.js
@@ -1,6 +1,6 @@
 //File : src/Tembo._.componentFactory.js
 
-(function(Tembo){
+module.exports = function(Tembo){
   'use strict';
 
   Tembo._.componentFactory = function(structure){
@@ -42,5 +42,4 @@
     };
     return TemboComponent;
   };
-
-})(this.Tembo);
+};

--- a/src/core/Tembo.core.deeplyCompare.js
+++ b/src/core/Tembo.core.deeplyCompare.js
@@ -1,3 +1,5 @@
+module.exports = function(Tembo){
+  'use strict';
 Tembo._.upCall = function(lifecycleMethod,instance){
   if (instance.component){
     if (instance.component.componentWillUnmount){
@@ -9,7 +11,6 @@ Tembo._.upCall = function(lifecycleMethod,instance){
     console.log('if your code reach this line, send-me a e-mail gui_souza@me.com . I would love to work with you in my new project');
   }
 };
-
 
   Tembo._.patchAttributes = function(instance,newInstance){
 
@@ -35,7 +36,6 @@ Tembo._.upCall = function(lifecycleMethod,instance){
     Array.prototype.forEach.call(newInstance.children,function(element){
       if (!SilentDiff[element.getAttribute('data-tamboId')])
         SilentDiff[element.getAttribute('data-tamboId')] = {};
-
       SilentDiff[element.getAttribute('data-tamboId')].b = element;
     });
 
@@ -51,7 +51,6 @@ Tembo._.upCall = function(lifecycleMethod,instance){
         }
     }
 
-
       // newInstance.attributes,function(attr){
       // instance.setAttribute(attr.localName,attr.value);
     // });
@@ -63,17 +62,7 @@ Tembo._.upCall = function(lifecycleMethod,instance){
     }
   };
 
-
-
-
-
-
-
-
-
-//File : src/Tembo._.deeplyCompare.js
-(function(Tembo){
-  'use strict';
+  //File : src/Tembo._.deeplyCompare.js
 
   Tembo._.deeplyCompare = function(element,reRenderedElement){
 
@@ -90,5 +79,4 @@ Tembo._.upCall = function(lifecycleMethod,instance){
     return false;
 
   };
-
-})(this.Tembo);
+};

--- a/src/core/Tembo.core.deeplyCompare.js
+++ b/src/core/Tembo.core.deeplyCompare.js
@@ -12,44 +12,52 @@ Tembo._.upCall = function(lifecycleMethod,instance){
   }
 };
 
-  Tembo._.patchAttributes = function(instance,newInstance){
+  Tembo._.patchAttributes = function(component,newComponent){
 
-    Array.prototype.forEach.call(newInstance.attributes,function(attr){
+    var instance = component.instance;
+    var oldProps = component.props;
+    var newProps = newComponent.props;
 
-      if (attr.localName !== 'data-tamboid'){
-        instance.setAttribute(attr.localName,attr.value);
-      }
-
+    Object.keys(newProps).forEach(function(key){
+      if (key === 'data-tamboId') return;
+      if (key === 'children') return;
+      if (oldProps[key] === newProps[key]) return;
+      Tembo.$.setProp(instance,key,newProps[key]);
     });
   };
 
   Tembo._.patchChildren = function(instance,newInstance){
 
     var SilentDiff = {};
-    Array.prototype.forEach.call(instance.children,function(element){
-      if (!SilentDiff[element.getAttribute('data-tamboId')])
-        SilentDiff[element.getAttribute('data-tamboId')] = {};
+    var children = Tembo.$.getChildren(intstance);
+    children.forEach(function(element){
+      var id = Tembo.$.getId(element);
+      if (!SilentDiff[id]) SilentDiff[id] = {};
 
-      SilentDiff[element.getAttribute('data-tamboId')].a = element;
+      SilentDiff[id].a = element;
     });
 
-    Array.prototype.forEach.call(newInstance.children,function(element){
-      if (!SilentDiff[element.getAttribute('data-tamboId')])
-        SilentDiff[element.getAttribute('data-tamboId')] = {};
-      SilentDiff[element.getAttribute('data-tamboId')].b = element;
+    var newChildren = Tembo.$.getChildren(newInstance);
+    newChildren.forEach(function(element){
+      var id = Tembo.$.getId(element);
+      if (!SilentDiff[id]) SilentDiff[id] = {};
+      SilentDiff[id].b = element;
     });
 
-    for(var key in SilentDiff){
-        var patch = SilentDiff[key];
-        if (patch.a === undefined && patch.b !== undefined){
-          Tembo._.upCall('componentWillUnmount',patch.b);
-          instance.appendChild(patch.b);
-        }
-        if (patch.a !== undefined && patch.b === undefined){
-          Tembo._.upCall('componentWillUnmount',patch.a);
-          instance.removeChild(patch.a);
-        }
-    }
+    Object.keys(SilentDiff).forEach(function(key){
+      var patch = SilentDiff[key];
+      if (patch.a === undefined && patch.b !== undefined){
+        Tembo._.upCall('componentWillMount',patch.b);
+        Tembo.$.appendChild(instance,patch.b);
+      }else if (patch.a !== undefined && patch.b === undefined){
+        Tembo._.upCall('componentWillUnmount',patch.a);
+        Tembo.$.removeChild(instance,patch.a);
+      }else{
+        // if a !== b
+        // Tembo._.upCall('componentWillUpdate',patch.a,patch.b);
+        // Tembo.$.replace(instance,patch.a,patch.b);
+      }
+    });
 
       // newInstance.attributes,function(attr){
       // instance.setAttribute(attr.localName,attr.value);
@@ -57,8 +65,17 @@ Tembo._.upCall = function(lifecycleMethod,instance){
   };
 
   Tembo._.patchText = function(instance,newInstance){
-    if (!instance.hasChildNodes()){
-        instance.textContent = newInstance.textContent;
+    var children = Tembo.$.getChildren(newInstance);
+    if (!children.length || children.length === 1 && Tembo.$.isText(children[0])){
+      var oldChildren = Tembo.$.getChildren(newInstance);
+      if (oldChildren.length){
+        oldChildren.forEach(function(child){
+          Tembo._.upCall('componentWillUnmount',child);
+          Tembo.$.removeChild(instance,child);
+        });
+      }
+      Tembo.$.setText(instance,Tembo.$.getText(newInstance));
+      return true;
     }
   };
 
@@ -72,9 +89,10 @@ Tembo._.upCall = function(lifecycleMethod,instance){
     newInstance.instance = newInstance.render();
     newInstance.instance.component = newInstance;
 
-    Tembo._.patchAttributes(instance.instance,newInstance.instance);
-    Tembo._.patchText(instance.instance,newInstance.instance);
-    Tembo._.patchChildren(instance.instance,newInstance.instance);
+    Tembo._.patchAttributes(instance,newInstance);
+    if (!Tembo._.patchText(instance.instance,newInstance.instance)){
+      Tembo._.patchChildren(instance.instance,newInstance.instance);
+    }
 
     return false;
 

--- a/src/core/tembo.El.js
+++ b/src/core/tembo.El.js
@@ -1,6 +1,9 @@
+
+module.exports = function(Tembo){
+  'use strict';
 Tembo._.can('attachProps',function(element,props,content){
   var prop;
-  if(element.isTemboComponent && element.isTemboComponent !== undefined){
+  if (element.isTemboComponent && element.isTemboComponent !== undefined){
     if (!element.props){
       element.props = {};
     }
@@ -8,29 +11,25 @@ Tembo._.can('attachProps',function(element,props,content){
       for(prop in props){
         element.props[prop] = props[prop];
       }
-      element.props.children = content;
+    element.props.children = content;
   }else{
     element = document.createElement(element);
     element = Tembo.append(element,content);
     for(var attr in props){
 
-        if (attr.indexOf('on') === 0){
-          var event = attr.replace('on','').toLowerCase();
-          element.addEventListener(event,props[attr],false);
-        }else{
-          if (attr !== 'children')
-          element.setAttribute(attr,props[attr]);
-        }
+      if (attr.indexOf('on') === 0){
+        var event = attr.replace('on','').toLowerCase();
+        element.addEventListener(event,props[attr],false);
+      }else{
+        if (attr !== 'children')
+        element.setAttribute(attr,props[attr]);
+      }
     }
   }
-    return element;
+  return element;
 });
 
-
-//File : src/Tembo.El.js
-
-(function(Tembo){
-  'use strict';
+  //File : src/Tembo.El.js
 
   Tembo.El = function(type,props,content){
     this.type = type;
@@ -48,5 +47,4 @@ Tembo._.can('attachProps',function(element,props,content){
     return element;
 
   };
-
-})(this.Tembo);
+};

--- a/src/core/tembo.El.js
+++ b/src/core/tembo.El.js
@@ -13,18 +13,8 @@ Tembo._.can('attachProps',function(element,props,content){
       }
     element.props.children = content;
   }else{
-    element = document.createElement(element);
+    element = Tembo.$.createElement(element,props);
     element = Tembo.append(element,content);
-    for(var attr in props){
-
-      if (attr.indexOf('on') === 0){
-        var event = attr.replace('on','').toLowerCase();
-        element.addEventListener(event,props[attr],false);
-      }else{
-        if (attr !== 'children')
-        element.setAttribute(attr,props[attr]);
-      }
-    }
   }
   return element;
 });

--- a/src/interface/tembo.createClass.js
+++ b/src/interface/tembo.createClass.js
@@ -1,8 +1,8 @@
 // File : src/Tembo.createClass.js
 
-(function(Tembo){
+module.exports = function(Tembo){
   'use strict';
   Tembo._.can('createClass',function(structure){
     return Tembo._.componentFactory(structure);
   });
-})(this.Tembo);
+};

--- a/src/interface/tembo.createElement.js
+++ b/src/interface/tembo.createElement.js
@@ -1,5 +1,8 @@
 module.exports = function(Tembo){
   'use strict';
+
+  var $ = Tembo.$;
+
   Tembo._.can('append',function(element,content){
     if (content)
     if (Array.isArray(content)){
@@ -16,8 +19,9 @@ module.exports = function(Tembo){
 
   Tembo._.can('appendChild',function(element,content){
     content.parent = element;
-    if (element.getAttribute('data-tamboId') === null){
-      element.setAttribute('data-tamboId','$0');
+    var elemID = $.getId(element);
+    if (!elemID){
+      $.setId(element,'$0');
     }
     if (element.childIndex === undefined){
       element.childIndex = 0;
@@ -30,14 +34,14 @@ module.exports = function(Tembo){
       if (content.render){
         content = Tembo.renderTree(content);
         content.parent = element;
-        content.setAttribute('data-tamboId',content.parent.getAttribute('data-tamboId')+'.$'+content.parent.childIndex);
-        element.appendChild(content);
+        $.setId(content,elemID+'.$'+content.parent.childIndex);
+        $.appendChild(element,content);
         return element;
       }
 
       if (content.tagName){
-        content.setAttribute('data-tamboId',content.parent.getAttribute('data-tamboId')+'.$'+content.parent.childIndex);
-        element.appendChild(content);
+        $.setId(content,elemID+'.$'+content.parent.childIndex);
+        $.appendChild(element,content);
         return element;
       }
 
@@ -49,8 +53,7 @@ module.exports = function(Tembo){
       //   return element;
       // }
       if (typeof content === 'string'){
-
-        element.appendChild(document.createTextNode(content));
+        $.appendChild(element,$.createText(content));
         return element;
       }
     }

--- a/src/interface/tembo.createElement.js
+++ b/src/interface/tembo.createElement.js
@@ -1,4 +1,5 @@
-
+module.exports = function(Tembo){
+  'use strict';
   Tembo._.can('append',function(element,content){
     if (content)
     if (Array.isArray(content)){
@@ -13,12 +14,10 @@
 
   });
 
-
-
   Tembo._.can('appendChild',function(element,content){
     content.parent = element;
     if (element.getAttribute('data-tamboId') === null){
-        element.setAttribute('data-tamboId','$0');
+      element.setAttribute('data-tamboId','$0');
     }
     if (element.childIndex === undefined){
       element.childIndex = 0;
@@ -29,7 +28,6 @@
     if (content){
 
       if (content.render){
-        component = content;
         content = Tembo.renderTree(content);
         content.parent = element;
         content.setAttribute('data-tamboId',content.parent.getAttribute('data-tamboId')+'.$'+content.parent.childIndex);
@@ -42,6 +40,7 @@
         element.appendChild(content);
         return element;
       }
+
       // if (content.instance){
       //   if (content.componentDidMount)
       //     content.componentDidMount();
@@ -57,11 +56,8 @@
     }
   });
 
-
-
-
   Tembo._.can('setInitialState',function(element){
-    if(element.isTemboComponent){
+    if (element.isTemboComponent){
       if (element.getInitialState){
         if (!element.state)
           element.state = {};
@@ -72,21 +68,13 @@
     return element;
   });
 
-
-
-
-
-// File : src/Tembo.createElement.js
-
-(function(Tembo){
-
-  'use strict';
+  // File : src/Tembo.createElement.js
   Tembo._.can('createElement',function(element,props,content){
 
     if (!props)
       props = {};
 
-    if(arguments.length > 3){
+    if (arguments.length > 3){
       content = [];
       var index = 2;
       while(index < arguments.length){
@@ -94,7 +82,6 @@
         index++;
       }
     }
-
 
     if (element.prototype)
     if (element.prototype.isTemboComponent){
@@ -104,6 +91,5 @@
     }
 
     return new Tembo.El(element,props,content);
-
   });
-})(this.Tembo);
+};

--- a/src/interface/tembo.render.js
+++ b/src/interface/tembo.render.js
@@ -10,9 +10,8 @@ module.exports = function(Tembo){
     return component;
   });
 
-  Tembo._.can('render',function(component,element){
+  Tembo._.can('render',function(component){
     component.instance = Tembo.renderTree(component);
-    Tembo.appendChild(element,component.instance);
-
+    return Tembo.$.render(component,arguments);
   });
 };

--- a/src/interface/tembo.render.js
+++ b/src/interface/tembo.render.js
@@ -1,4 +1,5 @@
-(function(Tembo){
+
+module.exports = function(Tembo){
   'use strict';
   Tembo._.can('renderTree',function(component){
     if (component.render){
@@ -8,17 +9,10 @@
     }
     return component;
   });
-})(this.Tembo);
 
-
-
-//File : src/Tembo.render.js
-
-(function(Tembo){
-  'use strict';
   Tembo._.can('render',function(component,element){
     component.instance = Tembo.renderTree(component);
     Tembo.appendChild(element,component.instance);
 
   });
-})(this.Tembo);
+};

--- a/src/renderers/Blessed.js
+++ b/src/renderers/Blessed.js
@@ -1,0 +1,98 @@
+module.exports.render = function(component,args){
+  var parent = args[1];
+  parent.append(component.instance);
+  return component.instance;
+};
+
+module.exports.getId = function(element){
+  return element._tamboId;
+};
+
+module.exports.setId = function(element,id){
+  return element._tamboId = id;
+};
+
+module.exports.appendChild = function(parent,child){
+  return parent.append(child);
+};
+
+module.exports.removeChild = function(parent,child){
+  return parent.remove(child);
+};
+
+module.exports.replaceChild = function(parent,childA,childB){
+  parent.insertBefore(childB,childA);
+  parent.remove(childA);
+};
+
+module.exports.createText = function(text){
+  return blessed.text({
+    content : text
+  });
+};
+
+module.exports.createElement = function(tagName,props){
+  var events = Object.keys(props).filter(function(prop){
+    return /^on\W/.test(prop);
+  }).reduce(function(obj,key){
+    obj[key] = props[key];
+    delete props[key];
+    return obj;
+  },{});
+
+  var element = createBlessed(tagName,props);
+
+  Object.keys(events).forEach(function(ev){
+    ev = ev.replace('on','').toLowerCase();
+    element.on(ev,events[ev]);
+  });
+
+  return element;
+};
+
+function createBlessed(tagName,props){
+
+  switch(tagName){
+    case 'text':
+    case 'line':
+    case 'bigtext':{
+      return blessed[tagName](props);
+    }
+    case 'list':
+    case 'filemanager':
+    case 'listtable':
+    case 'listbar':{
+      return blessed[tagName](props);
+    }
+    case 'form':
+    case 'textarea':
+    case 'textbox':
+    case 'button':
+    case 'checkbox':
+    case 'radioset':
+    case 'radiobutton':{
+      return blessed[tagName](props);
+    }
+    case 'prompt':
+    case 'question':
+    case 'message':
+    case 'loading':{
+      return blessed[tagName](props);
+    }
+    case 'progressbar':
+    case 'log':
+    case 'table':{
+      return blessed[tagName](props);
+    }
+    case 'terminal':
+    case 'image':
+    case 'ansiimage':
+    case 'overlayimage':
+    case 'video':
+    case 'layout':{
+      return blessed[tagName](props);
+    }
+    default:
+      throw new Error(tagName + ' does not exists');
+  }
+}

--- a/src/renderers/DOM.js
+++ b/src/renderers/DOM.js
@@ -1,0 +1,75 @@
+
+var DOM = document;
+
+module.exports.setDOM = function(newDom){
+  DOM = newDom;
+};
+
+if (typeof document === 'object'){
+  module.exports.setDOM(document);
+}
+
+module.exports.render = function(component,args){
+  var parent = args[1];
+  parent.appendChild(component.instance);
+  return component.instance;
+};
+
+module.exports.getId = function(element){
+  return element.getAttribute('data-tamboId');
+};
+
+module.exports.setId = function(element,id){
+  return element.setAttribute('data-tamboId',id);
+};
+
+module.exports.setProp = function(element,key,value){
+  return element.setAttribute(key,value);
+};
+
+module.exports.getChildren = function(parent){
+  return Array.prototype.slice.call(parent.children);
+};
+
+module.exports.appendChild = function(parent,child){
+  return parent.appendChild(child);
+};
+
+module.exports.removeChild = function(parent,child){
+  return parent.removeChild(child);
+};
+
+module.exports.replaceChild = function(parent,childA,childB){
+  return parent.replaceChild(childA,childB);
+};
+
+module.exports.createText = function(text){
+  return DOM.createTextNode(text);
+};
+
+module.exports.getText = function(node){
+  return node.textContent;
+};
+
+module.exports.setText = function(node,text){
+  return node.textContent = text;
+};
+
+module.exports.isText = function(textNode){
+  return textNode.nodeType === 3;
+};
+
+module.exports.createElement = function(tagName,props){
+  var element = DOM.createElement(tagName);
+  for(var attr in props){
+
+    if (attr.indexOf('on') === 0){
+      var event = attr.replace('on','').toLowerCase();
+      element.addEventListener(event,props[attr],false);
+    }else{
+      if (attr !== 'children')
+      element.setAttribute(attr,props[attr]);
+    }
+  }
+  return element;
+};

--- a/src/renderers/String.js
+++ b/src/renderers/String.js
@@ -1,0 +1,105 @@
+
+
+module.exports.render = function(component){
+  return component.instance.toString();
+};
+
+module.exports.getId = function(element){
+  return element._tamboID;
+};
+
+module.exports.setId = function(element,id){
+  return element._tamboID = id;
+};
+
+module.exports.setProp = function(element,key,value){
+  return element.props[key] = value;
+};
+
+module.exports.getChildren = function(parent){
+  return parent.children;
+};
+
+module.exports.appendChild = function(parent,child){
+  return parent.children.push(child);
+};
+
+module.exports.removeChild = function(parent,child){
+  var children = parent.children;
+  return children.splice(children.indexOf(child),1);
+};
+
+module.exports.replaceChild = function(parent,childA,childB){
+  var children = parent.children;
+  return children.splice(children.indexOf(childA),1,childB);
+};
+
+module.exports.createText = function(text){
+  return new TextWrapper(text);
+};
+
+module.exports.getText = function(node){
+  return node.children.length ? node.children[0] : '';
+};
+
+module.exports.setText = function(node,text){
+  node.children = [text];
+};
+
+module.exports.isText = function(textNode){
+  return textNode instanceof TextWrapper;
+};
+
+module.exports.createElement = function(tagName,props){
+  return new FakeElem(tagName,props);
+};
+
+function FakeElem(tagName,props){
+  this.tagName = tagName;
+  this.props = Object.create(props);
+  delete this.props.children;
+  this.children = [];
+};
+
+var proto = FakeElem.prototype;
+
+proto.toString = function(){
+  var props = this.props;
+  var tagName = this.tagName;
+  var ID = this._tamboID;
+  return '<' + tagName + ' ' +
+    'data-tamboId=\"' + ID + '\" ' +
+    Object.keys(props).reduce(reduceProperties.bind(void 0,props),'') +
+    '>' + this.children.join('') + '<' + this.tagName + '>';
+};
+
+function reduceProperties(props,str,key){
+  var value = props[key];
+  switch(typeof value){
+    case 'undefined':
+      return str;
+    case 'function':
+      console.log('It is possible to implement a json-rpc for events');
+      return str;
+    case 'object':
+      if (value === null) return str;
+      if (value instanceof Array){
+        return str + ' ' + key + '=\"' + value.join(' ') + '\"';
+      }
+      return str + ' ' + key + '=\"' + Object.keys(value)
+        .reduce(reduceObject.bind(void 0,value),'') + '\"';
+  }
+  return str + ' ' + key + '=\"' + value + '\"';
+}
+
+function reduceObject(obj,str,key){
+  return str + ';' + key + ':' + obj[key];
+}
+
+function TextWrapper(text){
+  this.text = text;
+}
+
+TextWrapper.prototype.toString = function(){
+  return this.text;
+};


### PR DESCRIPTION
This is something that has frustrated me about react at first and its the seperation between how the elements are managed. These types of templating languges should arguable be abstract with the implementation able to be handled elsewhere. This presents the opportunity to implement other forms of rendering such as String (serverside / webworker), Blessed (https://github.com/chjj/blessed#element-from-node) and possibly image.

This depends on pull request #5 
